### PR TITLE
Added 0 seconds timer

### DIFF
--- a/lua/terrortown/autorun/shared/sh_classes_player.lua
+++ b/lua/terrortown/autorun/shared/sh_classes_player.lua
@@ -319,15 +319,14 @@ function plymeta:GivePassiveClassEquipment(classData)
 		end
 	end
 
-	timer.Simpel(0, function()
-		if passiveWeapons and #passiveWeapons > 0 then
-			for _, v in ipairs(passiveWeapons) do
-				if not self:HasWeapon(v) then
-					self:GiveClassWeapon(v, true)
+	timer.Simple(0, function()
+		if not passiveWeapons or #passiveWeapons == 0 then return end
 
-					self.passiveNewWeps[#self.passiveNewWeps + 1] = v
-				end
-			end
+		for _, v in ipairs(passiveWeapons) do
+			if self:HasWeapon(v) then continue end
+
+			self:GiveClassWeapon(v, true)
+			self.passiveNewWeps[#self.passiveNewWeps + 1] = v
 		end
 	end)
 


### PR DESCRIPTION
This prevents an anomaly where players pickup all surrounding weapons once they received their class weapons on round start.